### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/azcausal/remote/client.py
+++ b/azcausal/remote/client.py
@@ -32,7 +32,7 @@ class REST(Endpoint):
 
     def send(self, content):
         headers = {'Content-Type': 'application/json'}
-        resp = requests.post(self.url, json=content, auth=self.auth, headers=headers)
+        resp = requests.post(self.url, json=content, auth=self.auth, headers=headers, timeout=60)
 
         if resp.ok:
             return resp.json()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fazcausal%7C73e99b536062f005d56df63bf257ced80b97ce63)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
